### PR TITLE
Fix error "error: package bolts does not exist"

### DIFF
--- a/src/android/ImageResizer.java
+++ b/src/android/ImageResizer.java
@@ -26,8 +26,6 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 
-import bolts.Task;
-
 public class ImageResizer extends CordovaPlugin {
   private static final int ARGUMENT_NUMBER = 1;
   private boolean switchWidthAndHeightExifs = false;


### PR DESCRIPTION
Cet import a été ajouté dans ce commit : https://github.com/BeMyEye/cordova-plugin-image-resizer/commit/a2f416f06f2cdad0c08231df3b4b7dffe0fe8f94
Ça ne compile plus depuis que j'ai supprimé le plugin facebook, j'imagine que le plugin facebook faisait que bolts.Task existe

```
[cordova] /Users/tonylucas/www/mobile-app/apps/compass/platforms/android/app/src/main/java/com/cordova/imageresizer/ImageResizer.java:29: error: package bolts does not exist
[cordova] import bolts.Task;
[cordova]             ^
```

Si je comprend bien, cet import n'est pas utilisé dans le fichier, donc je le supprime. Ça vous semble ok ?